### PR TITLE
Update Inkscape 1.0 and Python3

### DIFF
--- a/extension/latextext.py
+++ b/extension/latextext.py
@@ -16,6 +16,7 @@ from lxml import etree
 MAC = "Darwin"
 WINDOWS = "Windows"
 PLATFORM = platform.system()
+PY3 = int(platform.python_version()[0]) >= 3
 
 STANDALONE = False
 LOG_LEVEL = 3
@@ -95,9 +96,7 @@ class SvgTransformer:
 
     # matrix multiplication helper function
     def _matmult(self, a, b):
-        zip_b = zip(*b)
-        # uncomment next line if python 3 :
-        # zip_b = list(zip_b)
+        zip_b = list(zip(*b)) if PY3 else zip(*b)
         return [[sum(ele_a * ele_b for ele_a, ele_b in zip(row_a, col_b))
                  for col_b in zip_b] for row_a in a]
 
@@ -227,8 +226,8 @@ class SvgProcessor:
         self.options = options
         self.svg_input = infile
 
-        self.defaults = dict2obj({"scale": 1.0, "depth": 0.0, "fontsize": 10, 
-                                  "preamble": "","packages": "amsmath,amssymb","math": False, 
+        self.defaults = dict2obj({"scale": 1.0, "depth": 0.0, "fontsize": 10,
+                                  "preamble": "","packages": "amsmath,amssymb","math": False,
                                   "newline": False})
 
         # load from file or use existing document root
@@ -619,21 +618,21 @@ r"""\documentclass[%dpt]{%s}
 # commandline options shared by standalone application and inkscape extension
 def add_arguments(parser):
     parser.add_argument("-o", "--outfile", dest="outfile",
-                      help="write to output file or directory", metavar="FILE")
+                        help="write to output file or directory", metavar="FILE")
     parser.add_argument("-p", "--preamble", dest="preamble",
-                      help="latex preamble file", metavar="FILE")
+                        help="latex preamble file", metavar="FILE")
     parser.add_argument("-k", "--packages", dest="packages",
                         help="comma separated list of additional latex packages to be loaded",
                         metavar="LIST")
     parser.add_argument("-f", "--fontsize", dest="fontsize", type=int,
-                      help="latex base font size")
+                        help="latex base font size")
     parser.add_argument("-s", "--scale", dest="scale", type=float,
-                      help="apply additional scaling")
+                        help="apply additional scaling")
     parser.add_argument("-d", "--depth", dest="depth", type=int,
-                      help="maximum search depth for grouped text elements")
+                        help="maximum search depth for grouped text elements")
     parser.add_argument("-c", "--clean",
-                      action="store_true", dest="clean",
-                      help="remove all renderings")
+                        action="store_true", dest="clean",
+                        help="remove all renderings")
 
 
 if STANDALONE is False:
@@ -671,7 +670,7 @@ else:
                             action="store_true",
                             help="encapsulate all text in math mode")
         parser.add_argument("-v", "--verbose", default=False,
-                          action="store_true", dest="verbose")
+                            action="store_true", dest="verbose")
         parser.add_argument("svg", type=str, nargs='+',
                             metavar="FILE",
                             help="SVGfile(s)")

--- a/extension/latextext.py
+++ b/extension/latextext.py
@@ -13,7 +13,7 @@ import re
 from lxml import etree
 
 
-MAC = "Mac OS"
+MAC = "Darwin"
 WINDOWS = "Windows"
 PLATFORM = platform.system()
 
@@ -587,8 +587,18 @@ r"""\documentclass[%dpt]{%s}
         # Convert PDF to SVG
         if PLATFORM == WINDOWS:
             PDF2SVG_PATH = os.path.join(os.path.realpath(EXT_PATH), 'pdf2svg')
+        if PLATFORM == MAC:
+            if os.path.exists('/opt/local/bin/pdf2svg'):
+                PDF2SVG_PATH = '/opt/local/bin'
+            elif os.path.exists('/usr/local/bin/pdf2svg'):
+                PDF2SVG_PATH = '/usr/local/bin'
+            elif shutil.which("pdf2svg"):
+                PDF2SVG_PATH = os.path.dirname(shutil.which("pdf2svg"))
+            else:
+                log_error('PDF2SVG_PATH not found.')
         else:
             PDF2SVG_PATH = ''
+
         self._exec_command([os.path.join(PDF2SVG_PATH, 'pdf2svg'), os.path.join(tmp_path, 'tmp.pdf'), os.path.join(tmp_path, 'tmp.svg'), '1'])
 
         tree = etree.parse(os.path.join(tmp_path, 'tmp.svg'))

--- a/extension/latextext.py
+++ b/extension/latextext.py
@@ -70,7 +70,7 @@ def log_message(msg_level, *msg):
         print(*msg)
     else:
         for m in msg:
-            inkex.debug(m)
+            inkex.utils.debug(m)
 
 
 def set_log_level(l):
@@ -711,6 +711,6 @@ if __name__ == "__main__":
     if STANDALONE is False:
         # run the extension
         effect = RenderLatexEffect()
-        effect.affect()
+        effect.run()
     else:
         main_standalone()


### PR DESCRIPTION
Hi,

After upgrading to Inkscape 1.0 on macOS, I was running into the same issue as #24.

This PR includes:
* [x] Changes to match the [latest `inkex` requirements](https://wiki.inkscape.org/wiki/index.php/Updating_your_Extension_for_1.0)
* [x] Change `OptionParser` to `ArgumentParser` dependency.
* [x] Fixes some depreciation warnings.
* [x] Add macOS paths to find `PDF2SVG_PATH`
* [x] Change from `Mac OS` to `Darwin` for the platform name on macOS.
* [x] Add Python3 check on `SvgTransformer` for multiplication matrix function (instead of comment/uncomment function).

I tried to keep Python 2 and Python 3 compatibility but with the recent changes in Inkscape 1.0 it might not work for older versions. Additional tests may be required before merging it.
And it might be relevant to update `install.sh` as well based on the version of Inkscape installed.

Moreover, the location of the extension folder on macOS is now at
`/Users/<USERNAME>/Library/Application\ Support/org.inkscape.Inkscape/config/inkscape/extensions/` and no longer in `~/.config/inkscape/extensions/` (cf. `Edit > Preferences > System: User extensions`).

I hope this would help to re-enable this great plug-in for Inkscape users who migrated to 1.0.