### PR TITLE
Make it work with Inkscape 1.3

### DIFF
--- a/extension/latextext.py
+++ b/extension/latextext.py
@@ -16,6 +16,7 @@ from lxml import etree
 MAC = "Darwin"
 WINDOWS = "Windows"
 PLATFORM = platform.system()
+PY3 = int(platform.python_version()[0]) >= 3
 
 STANDALONE = False
 LOG_LEVEL = 3
@@ -95,9 +96,7 @@ class SvgTransformer:
 
     # matrix multiplication helper function
     def _matmult(self, a, b):
-        zip_b = zip(*b)
-        # uncomment next line if python 3 :
-        # zip_b = list(zip_b)
+        zip_b = list(zip(*b)) if PY3 else zip(*b)
         return [[sum(ele_a * ele_b for ele_a, ele_b in zip(row_a, col_b))
                  for col_b in zip_b] for row_a in a]
 
@@ -227,8 +226,8 @@ class SvgProcessor:
         self.options = options
         self.svg_input = infile
 
-        self.defaults = dict2obj({"scale": 1.0, "depth": 0.0, "fontsize": 10, 
-                                  "preamble": "","packages": "amsmath,amssymb","math": False, 
+        self.defaults = dict2obj({"scale": 1.0, "depth": 0.0, "fontsize": 10,
+                                  "preamble": "","packages": "amsmath,amssymb","math": False,
                                   "newline": False})
 
         # load from file or use existing document root
@@ -619,21 +618,21 @@ r"""\documentclass[%dpt]{%s}
 # commandline options shared by standalone application and inkscape extension
 def add_arguments(parser):
     parser.add_argument("-o", "--outfile", dest="outfile",
-                      help="write to output file or directory", metavar="FILE")
+                        help="write to output file or directory", metavar="FILE")
     parser.add_argument("-p", "--preamble", dest="preamble",
-                      help="latex preamble file", metavar="FILE")
+                        help="latex preamble file", metavar="FILE")
     parser.add_argument("-k", "--packages", dest="packages",
                         help="comma separated list of additional latex packages to be loaded",
                         metavar="LIST")
     parser.add_argument("-f", "--fontsize", dest="fontsize", type=int,
-                      help="latex base font size")
+                        help="latex base font size")
     parser.add_argument("-s", "--scale", dest="scale", type=float,
-                      help="apply additional scaling")
+                        help="apply additional scaling")
     parser.add_argument("-d", "--depth", dest="depth", type=int,
-                      help="maximum search depth for grouped text elements")
+                        help="maximum search depth for grouped text elements")
     parser.add_argument("-c", "--clean",
-                      action="store_true", dest="clean",
-                      help="remove all renderings")
+                        action="store_true", dest="clean",
+                        help="remove all renderings")
 
 
 if STANDALONE is False:
@@ -671,7 +670,7 @@ else:
                             action="store_true",
                             help="encapsulate all text in math mode")
         parser.add_argument("-v", "--verbose", default=False,
-                          action="store_true", dest="verbose")
+                            action="store_true", dest="verbose")
         parser.add_argument("svg", type=str, nargs='+',
                             metavar="FILE",
                             help="SVGfile(s)")

--- a/extension/latextext.py
+++ b/extension/latextext.py
@@ -13,7 +13,7 @@ import re
 from lxml import etree
 
 
-MAC = "Mac OS"
+MAC = "Darwin"
 WINDOWS = "Windows"
 PLATFORM = platform.system()
 
@@ -587,8 +587,18 @@ r"""\documentclass[%dpt]{%s}
         # Convert PDF to SVG
         if PLATFORM == WINDOWS:
             PDF2SVG_PATH = os.path.join(os.path.realpath(EXT_PATH), 'pdf2svg')
+        if PLATFORM == MAC:
+            if os.path.exists('/opt/local/bin/pdf2svg'):
+                PDF2SVG_PATH = '/opt/local/bin'
+            elif os.path.exists('/usr/local/bin/pdf2svg'):
+                PDF2SVG_PATH = '/usr/local/bin'
+            elif shutil.which("pdf2svg"):
+                PDF2SVG_PATH = os.path.dirname(shutil.which("pdf2svg"))
+            else:
+                log_error('PDF2SVG_PATH not found.')
         else:
             PDF2SVG_PATH = ''
+
         self._exec_command([os.path.join(PDF2SVG_PATH, 'pdf2svg'), os.path.join(tmp_path, 'tmp.pdf'), os.path.join(tmp_path, 'tmp.svg'), '1'])
 
         tree = etree.parse(os.path.join(tmp_path, 'tmp.svg'))

--- a/extension/latextext.py
+++ b/extension/latextext.py
@@ -70,7 +70,7 @@ def log_message(msg_level, *msg):
         print(*msg)
     else:
         for m in msg:
-            inkex.debug(m)
+            inkex.utils.debug(m)
 
 
 def set_log_level(l):
@@ -711,6 +711,6 @@ if __name__ == "__main__":
     if STANDALONE is False:
         # run the extension
         effect = RenderLatexEffect()
-        effect.affect()
+        effect.run()
     else:
         main_standalone()

--- a/extension/latextext.py
+++ b/extension/latextext.py
@@ -468,7 +468,7 @@ class SvgProcessor:
             if txt_empty:
                 log_debug("Empty text element, skipping...")
                 continue
-            if self.options.math and latex_string[0] is not '$':
+            if self.options.math and latex_string[0] != '$':
                 latex_string = '$' + latex_string + '$'
             log_debug(latex_string)
             rendergroup = lat2svg.render(latex_string, self.options.preamble, self.options.packages, self.options.fontsize, self.options.scale)

--- a/extension/latextext.py
+++ b/extension/latextext.py
@@ -79,8 +79,14 @@ def set_log_level(l):
     LOG_LEVEL = l
 
 
-import inkex
-STANDALONE = False
+######################
+#  Check if we are in the inkscape extension folder
+try:
+    import inkex
+    EXT_PATH = os.path.abspath(os.path.split(inkex.__file__)[0])
+    STANDALONE = False
+except ImportError:
+    STANDALONE = True
 
 
 ######################

--- a/extension/latextext.py
+++ b/extension/latextext.py
@@ -79,14 +79,8 @@ def set_log_level(l):
     LOG_LEVEL = l
 
 
-######################
-#  Check if we are in the inkscape extension folder
-try:
-    import inkex
-    EXT_PATH = os.path.abspath(os.path.split(inkex.__file__)[0])
-    STANDALONE = False
-except ImportError:
-    STANDALONE = True
+import inkex
+STANDALONE = False
 
 
 ######################

--- a/extension/latextext_gtk3.inx
+++ b/extension/latextext_gtk3.inx
@@ -4,7 +4,6 @@
 	<id>org.inkscape.render.latextext_gtk3</id>
 	<dependency type="executable" location="extensions">latextext.py</dependency>
 	<dependency type="executable" location="extensions">latextext_gtk3.py</dependency>
-    <dependency type="executable" location="extensions">inkex.py</dependency>
 	<effect>
 		<object-type>all</object-type>
 		<effects-menu>

--- a/extension/latextext_gtk3.py
+++ b/extension/latextext_gtk3.py
@@ -53,7 +53,7 @@ class Gtk3ParamGui(Gtk.Window):
 
         row_count = 0
         box0 = Gtk.Box(spacing=6)
-        grid.attach(Gtk.Label("Preamble File"), 0, row_count, 1, 1)
+        grid.attach(Gtk.Label(label="Preamble File"), 0, row_count, 1, 1)
         self.entryPreamble = Gtk.Entry()
         self.entryPreamble.set_text(options.preamble)
         self.entryPreamble.set_hexpand(True)
@@ -65,14 +65,14 @@ class Gtk3ParamGui(Gtk.Window):
         grid.attach(box0, 1, row_count, 1, 1)
 
         row_count += 1
-        grid.attach(Gtk.Label("Additional Packages"), 0, row_count, 1, 1)
+        grid.attach(Gtk.Label(label="Additional Packages"), 0, row_count, 1, 1)
         self.entryPackages = Gtk.Entry()
         self.entryPackages.set_text(options.packages)
         self.entryPackages.set_hexpand(True)
         grid.attach(self.entryPackages, 1, row_count, 1, 1)
 
         row_count += 1
-        grid.attach(Gtk.Label("Document base font size"), 0, row_count, 1, 1)
+        grid.attach(Gtk.Label(label="Document base font size"), 0, row_count, 1, 1)
         self.entryFontsize = Gtk.SpinButton.new_with_range(1, 32, 1)
         self.entryFontsize.set_value(options.fontsize)
         self.entryFontsize.set_hexpand(False)
@@ -82,29 +82,29 @@ class Gtk3ParamGui(Gtk.Window):
         self.entryScale = Gtk.SpinButton.new_with_range(0.01, 20.0, 0.05)
         self.entryScale.set_digits(2)
         self.entryScale.set_value(options.scale)
-        grid.attach(Gtk.Label("Scale factor"), 0, row_count, 1, 1)
+        grid.attach(Gtk.Label(label="Scale factor"), 0, row_count, 1, 1)
         grid.attach(self.entryScale, 1, row_count, 1, 1)
 
         row_count += 1
         self.entryDepth = Gtk.SpinButton.new_with_range(0, 100, 1)
         self.entryDepth.set_value(options.depth)
-        grid.attach(Gtk.Label("SVG/XML tree max. depth"), 0, row_count, 1, 1)
+        grid.attach(Gtk.Label(label="SVG/XML tree max. depth"), 0, row_count, 1, 1)
         grid.attach(self.entryDepth, 1, row_count, 1, 1)
 
         row_count += 1
-        grid.attach(Gtk.Label("Add \\\\ at every line break"), 0, row_count, 1, 1)
+        grid.attach(Gtk.Label(label="Add \\\\ at every line break"), 0, row_count, 1, 1)
         self.btnNewline = Gtk.CheckButton()
         self.btnNewline.set_active(options.newline)
         grid.attach(self.btnNewline, 1, row_count, 1, 1)
 
         row_count += 1
-        grid.attach(Gtk.Label("Encapsulate all text with ($..$)"), 0, row_count, 1, 1)
+        grid.attach(Gtk.Label(label="Encapsulate all text with ($..$)"), 0, row_count, 1, 1)
         self.btnMath = Gtk.CheckButton()
         self.btnMath.set_active(options.math)
         grid.attach(self.btnMath, 1, row_count, 1, 1)
 
         row_count += 1
-        grid.attach(Gtk.Label("Show log messages"), 0, row_count, 1, 1)
+        grid.attach(Gtk.Label(label="Show log messages"), 0, row_count, 1, 1)
         self.btnShowLog = Gtk.CheckButton()
         grid.attach(self.btnShowLog, 1, row_count, 1, 1)
 
@@ -128,10 +128,11 @@ class Gtk3ParamGui(Gtk.Window):
         self.set_default(btnApply)
 
     def on_select_preamble(self, widget):
-        dialog = Gtk.FileChooserDialog("Please choose a Latex preamble file", self,
+        dialog = Gtk.FileChooserDialog(self,
                                        Gtk.FileChooserAction.OPEN,
                                        (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                                        Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
+                                        Gtk.STOCK_OPEN, Gtk.ResponseType.OK),
+                                       label="Please choose a Latex preamble file")
         dialog.set_keep_above(True)
         dialog.set_modal(True)
         response = dialog.run()
@@ -174,4 +175,4 @@ class RenderLatexEffectGTK3(RenderLatexEffect):
 
 if __name__ == "__main__":
     effect = RenderLatexEffectGTK3()
-    effect.affect()
+    effect.run()


### PR DESCRIPTION
(and perhaps other versions of Inkscape; I've only tested against 1.3.2.)

This removes Python and PyGTK deprecation warnings and gets the extension ready to work with changes to the manifest format. It also pulls in fixes from [seignovert/LaTeXText](https://github.com/seignovert/LaTeXText).